### PR TITLE
Run the CEP extension in a web browser.

### DIFF
--- a/extensions/Bookalope/index.html
+++ b/extensions/Bookalope/index.html
@@ -278,9 +278,7 @@
   </div>
 
   <!-- https://github.com/Adobe-CEP/CEP-Resources/ -->
-  <script src="js/CEP/AgoraLib-7.0.0.js"></script>
-  <script src="js/CEP/CSInterface-9.2.0.js"></script>
-  <script src="js/CEP/Vulcan-9.2.0.js"></script>
+  <script src="js/CEP/CSInterface-9.2.0-Stubs.js"></script>
 
   <!-- https://github.com/adobe/loadIcons -->
   <script src="js/uses/loadIcons.js"></script>

--- a/extensions/Bookalope/js/CEP/CSInterface-9.2.0-Stubs.js
+++ b/extensions/Bookalope/js/CEP/CSInterface-9.2.0-Stubs.js
@@ -1,0 +1,155 @@
+
+/* CSInterface stubs.
+ * See also: https://github.com/Adobe-CEP/CEP-Resources/blob/master/CEP_9.x/CSInterface.js
+ *
+ * For the Bookalope extension to run, we need to stub out some of the CSInterface. However,
+ * because the interface implements synchronous filesystem functionality (e.g. writing files)
+ * and other Adobe application specific code that is not doable in browsers’ Javascript, the
+ * stub functions sometimes log only and return faked-up result values. The Bookalope extension
+ * is therefore testable and runable, but it’s not a fully functional duplicate.
+ */
+
+
+// Global error message string returned by CSInterface’s evalScript() function.
+const EvalScript_ErrMessage = "EvalScript error.";
+
+
+// The CSInterface() object describes the Adobe host application environment, and it provides
+// a number of functions to the extension.
+function CSInterface() {
+  this.hostEnvironment = {
+    "appName": undefined,
+    "appVersion": undefined,
+    "appLocale": undefined,
+    "appUILocale": undefined,
+    "appId": undefined,
+    "isAppOnline": undefined,
+    "appSkinInfo": {
+      "baseFontFamily": undefined,
+      "baseFontSize": undefined,
+      "appBarBackgroundColor": undefined,
+      "panelBackgroundColor": {
+        "color": {
+          "red": 68,
+          "green": 68,
+          "blue": 68,
+          "alpha": 0
+        }
+      },
+      "appBarBackgroundColorSRGB": undefined,
+      "panelBackgroundColorSRGB": undefined,
+      "systemHighlightColor": undefined
+    }
+  };
+}
+
+
+// Name of the “color changed” event triggered when the host application switches UI themes.
+CSInterface.THEME_COLOR_CHANGED_EVENT = "com.adobe.csxs.events.ThemeColorChanged";
+
+
+// No need to initialize the extension’s resource bundle here, because it doesn’t really
+// use it at this point. Revisit later, if necessary.
+CSInterface.prototype.initResourceBundle = function() {
+  return undefined;
+};
+
+
+// Add event listener functions that are called from the host application for certain events.
+// Without that host application, though, these events won’t trigger and therefore we don’t
+// handle these callback functions any further at this point.
+CSInterface.prototype.addEventListener = function(csEvent, callback) {
+  if (csEvent === CSInterface.THEME_COLOR_CHANGED_EVENT) {
+    // To do.
+  } else if (csEvent === "documentAfterActivate") {
+    // To do.
+  } else if (csEvent === "documentBeforeClose") {
+    // To do.
+  }
+};
+
+
+// The evalScript() function thunks down from the extension to the Adobe host application and
+// returns a result of the script that executed on the “other side”. Here too, without an
+// actual host application, we simply fake a result value which gets this extension running in
+// a browser context. The given callback function on “this side” receives a JSON result string.
+// For more details on these scripts, see jsx/bookalope.jsx.
+CSInterface.prototype.evalScript = function(script, callback) {
+  new Promise(function(resolve, reject) {
+
+    // Return some information about the host application’s configuration.
+    if (script === "getConfiguration();") {
+      let config = {
+        "app": {
+          "version": "14.0.0.0",
+          "user": "User Name",
+          "win": false
+        },
+        "fs": {
+          "data": "/path/to/home/Desktop",
+          "desktop": "/path/to/home/Desktop",
+          "tmp": "/tmp",
+          "separator": "/"
+        }
+      };
+      resolve(JSON.stringify(config));
+    }
+
+    // Create a new document inside of the host application (i.e. Adobe InDesign).
+    else if (script.startsWith("bookalopeCreateDocument(")) {
+      resolve(undefined);
+    }
+
+    // A document in the host application can have Bookalope extension-specific data attached
+    // to it. This one returns such data from the currently active document; having no host
+    // application, though, there is no active document and therefore no data.
+    else if (script === "bookalopeGetDocumentDataFromActive();") {
+      let data = {
+        "book-id": undefined,
+        "bookflow-id": undefined,
+        "beta": true
+      };
+      resolve(JSON.stringify(null));
+    }
+
+    // Needs to be implemented!
+    else {
+      // To do.
+    }
+  }).then(callback);
+};
+
+
+// And then there is the CEP context attached to the root of the DOM. It provides helper functions
+// that are not always available in the context of a normal web browser, so here too we simply stub
+// them out to get the extension running.
+window.cep = {
+  "fs": {
+    "deleteFile": function(filename) {
+      console.log("STUB: deleting file: " + filename);
+      return {"err": undefined};
+    },
+    "writeFile": function(filename, data, encoding) {
+      console.log("STUB: writing to file: " + filename);
+      return {"err": undefined};
+    },
+    "readFile": function(filename, encoding) {
+      console.log("STUB: reading from file: " + filename);
+      return {"err": undefined};
+    },
+    "showSaveDialogEx": function(title, formats, filename) {
+      console.log("STUB: open file dialog using default name: " + filename);
+      return {"err": undefined, "data": filename};
+    }
+  },
+  "encoding": {
+    "Base64": "Base64"
+  },
+  "util": {
+    "openURLInDefaultBrowser": function(url) {
+      console.log("STUB: open browser window with url: " + url);
+      window.open(url, "_blank");
+      return {"err": undefined};
+    }
+  }
+};

--- a/extensions/Bookalope/js/bookalope.js
+++ b/extensions/Bookalope/js/bookalope.js
@@ -577,18 +577,18 @@ function askSaveBookflowFile(bookflow, format, style) {
         showStatus("Uploading and analyzing document");
 
         // Read the user selected file.
-        var result = window.cep.fs.readFile(bookFile.path, window.cep.encoding.Base64);
-        if (result.err) {
-            showElementError(document.getElementById("input-file"), "Unable to load file (" + result.err + ")");
+        var reader = new FileReader();
+        reader.onerror = function() {
+            showElementError(document.getElementById("input-file"), "Unable to load file (" + reader.error + ")");
             hideSpinner();
-        } else {
-
+        };
+        reader.onload = function() {
             // Passing `undefined` as document type to setDocument() causes the server to
             // determine the type of the uploaded file. Also note that result.data is a
             // base-64 encoded binary, so we have to decode it before passing it to the
             // Bookalope wrapper. The wrapper will then encode it (again) before shipping
             // it off to the server.
-            bookflow.setDocument(bookFile.name, atob(result.data), undefined, bookSkipStructure)
+            bookflow.setDocument(bookFile.name, reader.result, undefined, bookSkipStructure)
             .then(function (bookflow) {
 
                 // Periodically poll the Bookalope server to update the Bookflow. Then check
@@ -619,7 +619,8 @@ function askSaveBookflowFile(bookflow, format, style) {
                 showServerError(error.message);
                 hideSpinner();
             });
-        }
+        };
+        reader.readAsBinaryString(bookFile);
     }
 
 


### PR DESCRIPTION
**Do not merge!**

This is an experimental branch to develop, test, and tinker with the extension code.

Considering the constraints of a web-browser, though, functions provided by Adobe CEP’s [CSInterface](https://github.com/Adobe-CEP/CEP-Resources/blob/master/CEP_9.x/CSInterface.js) and related data have been stubbed out. This enables the extension code to run in a browser context, except for selecting and saving files to the host fs (related [discussion](https://stackoverflow.com/questions/585234/how-to-read-and-write-into-file-using-javascript)).