### PR TITLE
Populate language picker

### DIFF
--- a/extensions/Bookalope/index.html
+++ b/extensions/Bookalope/index.html
@@ -145,8 +145,8 @@
                   <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true" aria-label="Alert">
                     <use xlink:href="#spectrum-icon-18-Alert"/>
                   </svg>
-                  <select id="input-book-language" name="input-book-language" data-placeholder="Choose Language" class="spectrum-Textfield-input spectrum-Picker-select">
-                    <option value="en-US" selected>English (United States)</option>
+                  <select id="input-book-language" name="input-book-language" data-placeholder="No languages to select yet" class="spectrum-Textfield-input spectrum-Picker-select">
+			  <!--<option value="en-US" selected>English (United States)</option>-->
                   </select>
                 </div>
               </div>

--- a/extensions/Bookalope/index.html
+++ b/extensions/Bookalope/index.html
@@ -145,7 +145,7 @@
                   <svg class="spectrum-Icon spectrum-Icon--sizeM spectrum-Textfield-validationIcon" focusable="false" aria-hidden="true" aria-label="Alert">
                     <use xlink:href="#spectrum-icon-18-Alert"/>
                   </svg>
-                  <select id="input-book-language" name="input-book-language" data-placeholder="No languages to select yet" class="spectrum-Textfield-input spectrum-Picker-select">
+                  <select id="input-book-language" name="input-book-language" data-placeholder="Choose language" class="spectrum-Textfield-input spectrum-Picker-select">
                   </select>
 					<!--<option value="en-US" selected>English (United States)</option>-->
                 </div>

--- a/extensions/Bookalope/index.html
+++ b/extensions/Bookalope/index.html
@@ -146,7 +146,7 @@
                     <use xlink:href="#spectrum-icon-18-Alert"/>
                   </svg>
                   <select id="input-book-language" name="input-book-language" data-placeholder="No languages to select yet" class="spectrum-Textfield-input spectrum-Picker-select">
-			  <!--<option value="en-US" selected>English (United States)</option>-->
+					<option value="en-US" selected>English (United States)</option>
                   </select>
                 </div>
               </div>

--- a/extensions/Bookalope/index.html
+++ b/extensions/Bookalope/index.html
@@ -146,8 +146,8 @@
                     <use xlink:href="#spectrum-icon-18-Alert"/>
                   </svg>
                   <select id="input-book-language" name="input-book-language" data-placeholder="No languages to select yet" class="spectrum-Textfield-input spectrum-Picker-select">
-					<option value="en-US" selected>English (United States)</option>
                   </select>
+					<!--<option value="en-US" selected>English (United States)</option>-->
                 </div>
               </div>
             </div>

--- a/extensions/Bookalope/js/bookalope.js
+++ b/extensions/Bookalope/js/bookalope.js
@@ -1351,7 +1351,7 @@ function askSaveBookflowFile(bookflow, format, style) {
         * Get language data
         */
 
-		fetchLanguages()
+        bookalope.fetchLanguages()
         .then(response => {
             // Populate the <select> options, and restore selection (if possible).
             populateSelectOptions("input-book-language", response);
@@ -1389,11 +1389,22 @@ function askSaveBookflowFile(bookflow, format, style) {
         clearErrors();
 
         let token = document.getElementById("input-bookalope-token").value;
+        let beta = document.getElementById("input-bookalope-beta").checked;
 
         if (token === "") {
             // Avoids warning on fresh startup with no token
             blockMetaData();
         } else if (isToken(token)) {
+            // On first startup, bookalope object may be undefined. Create it here.
+            // If it exists, the token/beta state will be updated.
+            bookalopeToken = token;
+            bookalopeBetaHost = beta;
+            bookalope = getBookalope(); // also uses isToken, error condition can be ignored
+
+            // Store new token/beta locally
+            setBookalopeAPIToken(token, beta);
+
+            // Do the actual unblock and data fetching
             unblockMetaData();
             fetchUIServerdata();
         } else {

--- a/extensions/Bookalope/js/bookalope.js
+++ b/extensions/Bookalope/js/bookalope.js
@@ -161,6 +161,22 @@ function hideSpinner() {
 
 
 /**
+ * Hide the  
+ */
+
+function unblockMetaData() {
+    document.querySelector("div[data-id='input-book-language'] > button").classList.remove("is-disabled");
+}
+
+function blockMetaData() {
+    let node = document.querySelector("#input-book-language").parentNode.querySelector("button");
+    if(node) {
+        node.classList.add("is-disabled");
+    }
+}
+
+
+/**
  * There is a status message box at the bottom of both panels. This function renders
  * a given message of the given class into that message box.
  *

--- a/extensions/Bookalope/js/bookalope.js
+++ b/extensions/Bookalope/js/bookalope.js
@@ -1355,16 +1355,16 @@ function askSaveBookflowFile(bookflow, format, style) {
         .then(response => {
             // Populate the <select> options, and restore selection (if possible).
             populateSelectOptions("input-book-language", response);
-
-            // Construct a new the picker menu based of the <select> options
-            populatePickerItems("input-book-language");
         })
         .catch(error => {
             // Same, but empty the options, thus also clearing the picker menu.
             populateSelectOptions("input-book-language", []);
-            populatePickerItems("input-book-language");
 
             showClientError(error);
+        })
+        .finally(() => {
+            // Construct a new the picker menu based of the <select> options
+            populatePickerItems("input-book-language");
         });
 
         /*

--- a/extensions/Bookalope/js/bookalope.js
+++ b/extensions/Bookalope/js/bookalope.js
@@ -506,6 +506,7 @@ function askSaveBookflowFile(bookflow, format, style) {
             return false;
         });
 
+
         // Depending on the Bookflow's current credit type, show/hide notes for the user.
         if (bookflow.credit === "pro") {
             document.getElementById("div-bookflow-type-none").classList.add("hidden");
@@ -857,7 +858,6 @@ function askSaveBookflowFile(bookflow, format, style) {
                     bookflow.update()
                     .then(function (bookflow) {
                         setBookalopeLinks(bookflow);
-			populateMetadataLanguagePicker();
                         showUpdate();
                         showStatusOk();
                     })
@@ -917,41 +917,42 @@ function askSaveBookflowFile(bookflow, format, style) {
 	* Retrieve the supported languages, and populate the metadata language picker
      */
 
-	function populateMetadataLanguagePicker() {
+	async function populateMetadataLanguagePicker() {
+		document.getElementById("input-book-name").value = "invoked pmlp";
+
 		var languagePicker = document.getElementById("input-book-language");
-		
-		// TODO remove all items.
-		
-		// Temporarely use a dummy object
-		var languagesList = [{
-		"code": "en-US",
-		"name": "English (US)"
-		}, {
-		"code": "es-ES",
-		"name": "Español (Spain)"
-		}, {
-		"code": "de-DE",
-		"name": "Deutsch"
-		}
-		]
-		
-		// var languagesList = getLanguages(); // returns promise.
-		// TODO ON success
-		languagePicker.setAttribute('data-placeholder', 'Choose language');
-		
-		languagesList.forEach (function (language) {
-			var opt = document.createElement('option');
+		var output;
+
+		output = await getLanguages().catch(
+			(e) => {document.getElementById("input-book-name").value = "error"; }
+		);
+			
+		// Add language options to (hidden) <select>. Todo, add to Adobe's picker.
+		/* In case of compatibility problems, use
 			opt.value = language.code;
 			opt.innerHTML = language.name;
 			languagePicker.appendChild(opt);
-			
-			// TODO compatible?
-			//languagePicker.appendChild(new Option(language.name, language.code));
-			}
-		)
+		*/
+		output.forEach (function (language) {
+			languagePicker.appendChild(new Option(language.name, language.code));
+		});
 		
+
+		document.getElementById("input-book-name").value = "invoked pmlp 2";
+/*
+		response => {
+			document.getElementById("input-book-name").value = "succeeded";
+					
+			//languagePicker.setAttribute('data-placeholder', 'Choose language');
+
+		}).catch(function(e) {
+			document.getElementById("input-book-name").value = "failed";
+			languagePicker.setAttribute('data-placeholder', 'No languages to select yet');
+		});
+	*/
+	
 		// TODO ON failure
-		languagePicker.setAttribute('data-placeholder', 'No languages to select yet');
+		//languagePicker.setAttribute('data-placeholder', 'No languages to select yet');
 	}
 
 
@@ -1035,6 +1036,20 @@ function askSaveBookflowFile(bookflow, format, style) {
                     label.textContent = this.getAttribute("data-placeholder");
                 }
             });
+
+			function test() {
+				var token = document.getElementById("input-bookalope-token").value;
+				if(!isToken(token)) {
+					showElementError(document.getElementById("input-bookalope-token"), "Invalid Token");
+					document.getElementById("input-bookalope-token").scrollIntoView(false);
+				}
+				else
+				{
+					populateMetadataLanguagePicker();
+				}
+			}
+			// register callback token change
+			document.getElementById("input-bookalope-token").addEventListener("blur", test);
 
             // Alright this is a funky Adobe Spectrum thing. Looking at the documentation for
             // Picker elements: https://opensource.adobe.com/spectrum-css/picker.html

--- a/extensions/Bookalope/js/bookalope.js
+++ b/extensions/Bookalope/js/bookalope.js
@@ -1032,13 +1032,14 @@ function askSaveBookflowFile(bookflow, format, style) {
 
             // On valid token, retrieve server UI data
             if(isToken(bookalopeToken)) {
-                getUIServerdata();
+                getUIServerdata(true);
             } else {
+                rebuildPickers(true);
                 blockMetaData();
             }
 
             // build the pickers (true for startup)
-            rebuildPickers(true);
+            //
 
             // And we're ready.
             showStatusOk();
@@ -1064,7 +1065,7 @@ function askSaveBookflowFile(bookflow, format, style) {
     *
     */
 
-	async function getUIServerdata() {
+	async function getUIServerdata(startup=false) {
 		document.getElementById("input-book-name").value = "invoked UI";
 
         // First get language data
@@ -1096,7 +1097,7 @@ function askSaveBookflowFile(bookflow, format, style) {
         });
 
         // Rebuild here, given await.
-        //rebuildPickers();
+        rebuildPickers(startup);
 /*
 		//languagePicker.setAttribute('data-placeholder', 'Choose language');
 		// TODO ON failure

--- a/extensions/Bookalope/js/bookalope.js
+++ b/extensions/Bookalope/js/bookalope.js
@@ -446,6 +446,8 @@ function askSaveBookflowFile(bookflow, format, style) {
     var bookHighlightIssues;
     var bookSkipStructure;
 
+    // Other additions
+    let tokenChangeTimeout;
 
     /**
      * Helper function which returns an existing BookalopeClient object, or creates
@@ -1462,9 +1464,27 @@ function askSaveBookflowFile(bookflow, format, style) {
             });
 
             // Register the callbacks for a change of authentication data (token/beta)
-			document.getElementById("input-bookalope-token").addEventListener("blur", () => {
-                authenticationChanged();
-            }); // TODO, add timeout
+            // Listening for "keyup" + "paste" covers most situations, except for a context menu "cut" that
+            // empties the input (or invalidates the token).
+            // That can be listened for using "change" which (like "onblur") triggers when loosing focus;
+            // However, currently it will also run after a completed "keyup" and "paste" event. Therefor, ignore
+            // this rare situation for now. If needed, the user can press 'enter' after a change.
+
+            // Listen for typed tokens
+            document.getElementById("input-bookalope-token").addEventListener("keyup", () => {
+                if(tokenChangeTimeout) {
+                    clearTimeout(tokenChangeTimeout);
+                }
+                tokenChangeTimeout = setTimeout(authenticationChanged, 1000);
+            });
+            // Listen for copy pasted tokens
+            document.getElementById("input-bookalope-token").addEventListener("paste", () => {
+                if(tokenChangeTimeout) {
+                    clearTimeout(tokenChangeTimeout);
+                }
+                tokenChangeTimeout = setTimeout(authenticationChanged, 100);
+            });
+            // Listen for Beta toggle
             document.getElementById("input-bookalope-beta").addEventListener("change", () => {
                 authenticationChanged();
             });

--- a/extensions/Bookalope/js/bookalope.js
+++ b/extensions/Bookalope/js/bookalope.js
@@ -857,6 +857,7 @@ function askSaveBookflowFile(bookflow, format, style) {
                     bookflow.update()
                     .then(function (bookflow) {
                         setBookalopeLinks(bookflow);
+			populateMetadataLanguagePicker();
                         showUpdate();
                         showStatusOk();
                     })
@@ -910,6 +911,48 @@ function askSaveBookflowFile(bookflow, format, style) {
             });
         }
     }
+
+
+    /**
+	* Retrieve the supported languages, and populate the metadata language picker
+     */
+
+	function populateMetadataLanguagePicker() {
+		var languagePicker = document.getElementById("input-book-language");
+		
+		// TODO remove all items.
+		
+		// Temporarely use a dummy object
+		var languagesList = [{
+		"code": "en-US",
+		"name": "English (US)"
+		}, {
+		"code": "es-ES",
+		"name": "Español (Spain)"
+		}, {
+		"code": "de-DE",
+		"name": "Deutsch"
+		}
+		]
+		
+		// var languagesList = getLanguages(); // returns promise.
+		// TODO ON success
+		languagePicker.setAttribute('data-placeholder', 'Choose language');
+		
+		languagesList.forEach (function (language) {
+			var opt = document.createElement('option');
+			opt.value = language.code;
+			opt.innerHTML = language.name;
+			languagePicker.appendChild(opt);
+			
+			// TODO compatible?
+			//languagePicker.appendChild(new Option(language.name, language.code));
+			}
+		)
+		
+		// TODO ON failure
+		languagePicker.setAttribute('data-placeholder', 'No languages to select yet');
+	}
 
 
     // First things first: get and initialize the Creative Suite Interface. There is much

--- a/extensions/Bookalope/js/uses/BookalopeClient.js
+++ b/extensions/Bookalope/js/uses/BookalopeClient.js
@@ -412,9 +412,31 @@ BookalopeClient.prototype.getImportFormats = function() {
  * @returns {Promise}
  */
 
-BookalopeClient.prototype.getLanguages = function() {
-  var bookalope = this;
+//BookalopeClient.prototype.
+getLanguages = function() {
 
+	return new Promise(function(resolve, reject) {
+	// Temporarely use a dummy object
+		var languagesList = [{
+			"code": "en-US",
+			"name": "English (US)"
+			}, {
+			"code": "es-ES",
+			"name": "Español (Spain)"
+			}, {
+			"code": "de-DE",
+			"name": "Deutsch"
+			}
+			];
+		setTimeout(function() {
+			resolve(languagesList);		
+		}, 1000);
+	}).catch(function(error) {
+	  reject(error);
+	});
+
+// This is the final version
+/*
   return new Promise(function(resolve, reject) {
     var url = "/api/languages";
     bookalope.httpGET(url)
@@ -432,6 +454,7 @@ BookalopeClient.prototype.getLanguages = function() {
       reject(error);
     });
   });
+*/
 };
 
 

--- a/extensions/Bookalope/js/uses/BookalopeClient.js
+++ b/extensions/Bookalope/js/uses/BookalopeClient.js
@@ -412,8 +412,7 @@ BookalopeClient.prototype.getImportFormats = function() {
  * @returns {Promise}
  */
 
-//BookalopeClient.prototype.
-let fetchLanguages = function() {
+BookalopeClient.prototype.fetchLanguages = function() {
 
 	return new Promise(function(resolve, reject) {
 	// Temporarely use a dummy object

--- a/extensions/Bookalope/js/uses/BookalopeClient.js
+++ b/extensions/Bookalope/js/uses/BookalopeClient.js
@@ -405,6 +405,37 @@ BookalopeClient.prototype.getImportFormats = function() {
 
 
 /**
+ * Get a list of supported Bookalope languages. Returns a promise that
+ * is fulfilled with a list of language instances or rejected with a BookalopeError.
+ *
+ * @async
+ * @returns {Promise}
+ */
+
+BookalopeClient.prototype.getLanguages = function() {
+  var bookalope = this;
+
+  return new Promise(function(resolve, reject) {
+    var url = "/api/languages";
+    bookalope.httpGET(url)
+    .then(function(response) {
+
+      // Create and populate a list of language instances from the response data.
+      var languagesList = [];
+      response.languages.import.forEach(function(language) {
+        languagesList.push(new Language(language.code, language.name));
+      });
+
+      resolve(languagesList);
+    })
+    .catch(function(error) {
+      reject(error);
+    });
+  });
+};
+
+
+/**
  * Get a list Bookshelves. Returns a promise that is fulfilled with a list of
  * Bookshelf instances or rejected with a BookalopeError.
  *
@@ -590,6 +621,14 @@ var Format = function(name, mime, exts) {
   this.name = name;
   this.mime = mime;
   this.fileExts = exts;
+};
+
+
+/* A Language instance (...) */
+
+var Language = function(code, name) {
+	this.code = code;
+	this.name = name;
 };
 
 

--- a/extensions/Bookalope/js/uses/BookalopeClient.js
+++ b/extensions/Bookalope/js/uses/BookalopeClient.js
@@ -413,24 +413,23 @@ BookalopeClient.prototype.getImportFormats = function() {
  */
 
 //BookalopeClient.prototype.
-getLanguages = function() {
+let fetchLanguages = function() {
 
 	return new Promise(function(resolve, reject) {
 	// Temporarely use a dummy object
-		var languagesList = [{
-			"code": "en-US",
+		let languagesList = [{
+			"value": "en-US",
 			"name": "English (US)"
 			}, {
-			"code": "es-ES",
+			"value": "es-ES",
 			"name": "Español (Spain)"
 			}, {
-			"code": "de-DE",
+			"value": "de-DE",
 			"name": "Deutsch"
-			}
-			];
+		}];
 		setTimeout(function() {
 			resolve(languagesList);		
-		}, 1000);
+		}, 2000);
 	}).catch(function(error) {
 	  reject(error);
 	});


### PR DESCRIPTION
Hi, we've discussed changing the language picker elsewhere. Here's the first PR for review.
There's some todo's listed below, those will get handled along the way. 

**Main additions/changes**
Language data is retrieved, and inserted into a dropdown menu.

Let's walk trough it:
1. upon entering a token, and exiting the token field, `authenticationChanged()` is invoked [see todos]
2. `authenticationChanged()` checks for a valid token. If found, it update the UI using `fetchUIServerData()`
3. that one gets the language data, inserts it into the `<select>`, and calls for rebuilding the picker.

**Splitting the picker**
The existing picker code could be fully re-used, but was split out in two parts, with very few changes or additions. But moving code makes the diff large.

1. create the picker (once during startup) --> `buildPickers()`
2. clear and recreate the menu items, from the associated `<select>` content --> `populatePickerItems()`

---

**Todos**
Minor ones actually, but I hate to omit them :)

1. Use actual server-side data (not implemented yet)

2. ~~Improve token change event handling~~

3. `fetchUIServerdata()`
- ~~improve promises~~

4. `fetchLanguages()`
- ~~register as bookalope method~~
- test existing catch/reject in fetchLanguages().

5. metadata reset by showUpload()
- also set Pickers to their default placeholder (WIP)

6. block metadata fields (WIP)